### PR TITLE
Fix the `[compat]` entry for Julia

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,4 +6,4 @@ PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 SimplePosets = "b2aef97b-4721-5af9-b440-0bad754dc5ba"
 
 [compat]
-julia = "≥ 1.0.0"
+julia = "1"


### PR DESCRIPTION
The current `[compat]` entry for Julia is not upper-bounded.

This pull request fixes the `[compat]` entry.

cc: @scheinerman 